### PR TITLE
added npm start and config based selection for in adapter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var manager = require('./lib/manager');
-var inAdapter = require('./lib/inAdapters/fileAdapter');
+var settings = require('./package.json');
+var inAdapter = require(settings.in_adapter.type);
 var outAdapter = require('./lib/outAdapters/consoleAdapter');
 
 var main = function() {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha",
     "win_istanbul": "istanbul.cmd cover node_modules\\mocha\\bin\\_mocha",
-    "istanbul": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha test/*.js test/**/*.js"
+    "istanbul": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha test/*.js test/**/*.js",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",
@@ -36,5 +37,8 @@
     "istanbul": "*",
     "mocha": "*",
     "rewire": "*"
+  },
+  "in_adapter": {
+    "type": "./lib/inAdapters/fileAdapter"
   }
 }


### PR DESCRIPTION
Added npm start index.js, seems to be a good pattern so no one has to guess at how to start the project. Might need to updated the documentation for this. Also, added in "in_adapter" to the package.json figured we could use that to configure which in adapter you prefer to use. 
