### PR TITLE
Fixes #13 by adding `--only-output-failures` flag.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
 "use strict";
 
+var _ = require('lodash');
 var manager = require('./lib/manager');
 var settings = require('./package.json');
 var inAdapter = require(settings.inAdapter.type);
 var outAdapter = require('./lib/outAdapters/consoleAdapter');
 
-var main = function() {
+var onlyOutputFails = _.contains(process.argv.slice(2), '--only-output-failures');
+var main = function(onlyOutputFails) {
   var runData = inAdapter.getRunData();
-  manager.run(runData, outAdapter);
+  manager.run(runData, outAdapter, onlyOutputFails);
 };
 
-main();
+main(onlyOutputFails);
 
 module.exports = {
   main: main

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -4,12 +4,14 @@ var uriCheck = require('./uriCheck');
 var _ = require('lodash');
 var async = require('async');
 
-var iterateURLs = function(concurrentRequests, sites) {
+var iterateURLs = function(concurrentRequests, sites, onlyOutputFails) {
   async.eachLimit(sites, concurrentRequests, uriCheck.checkUri, function(err) {
     if(err) {
       throw err;
     }
-    uriCheck.done();
+    if (!onlyOutputFails) {
+      uriCheck.done();
+    }
   });
 };
 
@@ -81,13 +83,16 @@ var expandExpectedTextInput = function(sites) {
   });
 };
 
-var run = function(runData, outAdapter) {
+var run = function(runData, outAdapter, onlyOutputFails) {
   var sites = expandExpectedTextInput(expandRequestUrlInput(runData.sites));
+  if (runData.allSites) {
+    runData.allSites.onlyOutputFails = onlyOutputFails;
+  }
 
   // At this point sites array has now been "normalized".
   // Now take the allSites data and apply that to each element of the sites
   // array that doesn't have that data
-  sites = _.map(sites, function(item){
+  sites = _.map(sites, function(item) {
     return _.assign(_.clone(runData.allSites), item);
   });
 
@@ -96,7 +101,7 @@ var run = function(runData, outAdapter) {
     concurrentRequests = 3;
   }
   uriCheck.init(outAdapter);
-  iterateURLs(concurrentRequests, sites);
+  iterateURLs(concurrentRequests, sites, onlyOutputFails);
 };
 
 module.exports = {

--- a/lib/outAdapters/consoleAdapter.js
+++ b/lib/outAdapters/consoleAdapter.js
@@ -31,7 +31,6 @@ var writeResult = function(result, uri) {
       break;
     case 'fail':
       console.log('X ' + uri.name + ' (' + uri.requestUrl + ') failed. Here are the problems:');
-      // console.log('uri.errors: ', uri.errors);
       if(uri.errors) {
         uri.errors = organizeErrors(uri.errors);
         _.forEach(uri.errors, function(error) { console.log('  - ' + error); } );

--- a/lib/uriCheck.js
+++ b/lib/uriCheck.js
@@ -6,7 +6,7 @@ var debug = require('debug')('http-status-check:uriCheck');
 require('sugar');
 var outAdapter;
 
-var init = function(output){
+var init = function(output) {
   outAdapter = output;
 };
 
@@ -98,7 +98,9 @@ function checkBody(site, body, accumulatedFails) {
 
 var checkUri = function(site, callback) {
   if (site.disabled) {
-    outAdapter.writeResult('disabled', site);
+    if (!site.onlyOutputFails) {
+      outAdapter.writeResult('disabled', site);
+    }
     return callback(null);
   }
 
@@ -154,7 +156,9 @@ var checkUri = function(site, callback) {
     checkBody(site, body, accumulatedFails);
 
     if(accumulatedFails.length === 0) {
-      outAdapter.writeResult('success', site);
+      if (!site.onlyOutputFails) {
+        outAdapter.writeResult('success', site);
+      }
       return callback(null);
     } else {
       site.errors = accumulatedFails;


### PR DESCRIPTION
This should do it. Here's how it looks on my setup.

```
☁  http-status-check [suppress-successful-output-flag] ⚡ node index.js
X koddsson.com https (https://koddsson.com) failed. Here are the problems:
  - code: ECONNREFUSED
  - errno: ECONNREFUSED
  - syscall: connect
_ LinkSilk WWW (http://www.linksilk.com) working as expected.
_ Google (http://google.com) testing disabled.
_ LinkSilk (http://linksilk.com) working as expected.
_ Missing URL example (http://www.guyellisrocks.com/2014/06/will-this-get-written.html) working as expected.
_ HTTP Status Check on Guy's Blog (http://www.guyellisrocks.com/2014/06/http-status-check.html) working as expected.
_ LinkSilk Redirect To 200 (http://www.linksilk.com) working as expected.
A total of 7 URIs were tested.
Failure count:  1
Success count:  5
Disable count:  1
☁  http-status-check [suppress-successful-output-flag] ⚡ node index.js --only-output-failures
X koddsson.com https (https://koddsson.com) failed. Here are the problems:
  - code: ECONNREFUSED
  - errno: ECONNREFUSED
  - syscall: connect
☁  http-status-check [suppress-successful-output-flag] ⚡
```
